### PR TITLE
fixed navbar bug

### DIFF
--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -103,10 +103,6 @@ hr {
     }
 }
 @media screen and (min-width: 375px) and (orientation: portrait) {
-    #nav-bar {
-        width: 250px;
-    }
-
     .nav-item * {
         width: 100%;
     }
@@ -137,11 +133,6 @@ hr {
     }
 }
 @media screen and (orientation: landscape) and (max-width: 900px) {
-    #nav-bar {
-        width: 80%;
-        align-items: center;
-        height: 100vh;
-    }
     .item-wrapper {
         height: auto;
     }

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -20,7 +20,6 @@ class Navbar extends Component {
         };
     }
     showNav = () => {
-        console.log(this.state.navbarWidth.length);
         if (
             this.state.navbarWidth.length &&
             this.state.navbarWidth.includes('%')
@@ -39,35 +38,51 @@ class Navbar extends Component {
         }
     };
     componentDidMount() {
+        // node = id="nav-bar"
         let node = this.navRef.current;
         let navWidth;
-        if (node) navWidth = window.getComputedStyle(node).width.split('px')[0];
-        if (node && navWidth !== this.state.navbarWidth)
+
+        // If id="nav-bar" exist  navWidth = navbar width.
+        if (node) {
+            navWidth = window.getComputedStyle(node).width.split('px')[0];
+        }
+
+        // if id = "nav-bar exist and navWidth is not equal to this.state.navbarWidth"
+        // Possiblly error for not updating in time.
+        if (node && navWidth !== this.state.navbarWidth) {
             this.setState({ navbarWidth: navWidth });
+        }
 
         if (
-            window.innerWidth < 900 ||
+            window.innerWidth <= 900 ||
             (window.screen.orientation.angle > 0 && window.innerWidth < 900)
-        )
+        ) {
             this.setState({ hamburger: 'block', navbar: 'none' });
-        else this.setState({ hamburger: '', navbar: '' });
-
+        } else {
+            this.setState({ hamburger: '', navbar: '' });
+        }
         window.addEventListener('resize', () => {
             if (
                 ((window.screen.orientation.angle === '90' &&
                     window.innerWidth < 900) ||
                     window.innerWidth < 900) &&
                 !this.state.hamburger.length
-            )
+            ) {
                 this.setState({ hamburger: 'block', navbar: 'none' });
-            else if (window.innerWidth >= 900 && this.state.hamburger.length)
+            } else if (
+                window.innerWidth >= 900 &&
+                this.state.hamburger.length
+            ) {
                 this.setState({ hamburger: '', navbar: '' });
-            node = this.navRef.current;
-            if (node)
+                node = this.navRef.current;
+            }
+            if (node) {
                 navWidth = window.getComputedStyle(node).width.split('px')[0];
-            if (node && navWidth !== this.state.navbarWidth)
+            }
+            if (node && navWidth !== this.state.navbarWidth) {
                 this.setState({ navbarWidth: navWidth });
-            this.showNav();
+                this.showNav();
+            }
         });
 
         window.addEventListener('orientationchange', () => {
@@ -83,11 +98,10 @@ class Navbar extends Component {
             node = this.navRef.current;
             if (node)
                 navWidth = window.getComputedStyle(node).width.split('px')[0];
-            console.log({ navWidth });
-            if (node && navWidth !== this.state.navbarWidth)
+            if (node && navWidth !== this.state.navbarWidth) {
                 this.setState({ navbarWidth: navWidth });
-
-            this.showNav();
+                this.showNav();
+            }
         });
     }
     render() {


### PR DESCRIPTION
[Trello task](https://trello.com/c/4SCOp2J4/124-navbar-mobile-bug)

Fixed navbar bugs:
1) On mobile clicking on input won't open a navbar.
2) On Google Chrome resizing from 900px to 0 won't open and close 50 times navbar.

What problem was:
1) I deleted a few min-width from the media screen that was messing with the navbar. Also, @sciortinomrc likes to write if statement like this
 ` if (node && navWidth !== this.state.navbarWidth)	
                this.setState({ navbarWidth: navWidth });`
This works for only one line, his second line `this.showNav();` wasn't picked up. So I added these {}

Possible improvements:
1) On Google Chrome there still a bug resizing window from 320px to 0 navbar opens up and closes. Since this is not an immediate problem I wanted to discuss here.
2) ComponentDidMount has too much code, for better code readability I could divide it into functions.  I want to check up here first, before changing the other person code.