### PR TITLE
fixed Redux devtools bug

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -5,7 +5,7 @@ import rootReducer from './reduces';
 
 const composeEnhancers =
     process.env.NODE_ENV === 'development'
-        ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
+        ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
         : null || compose;
 const store = createStore(
     rootReducer,


### PR DESCRIPTION
[Trello task](https://trello.com/c/qBPoR0FO/157-redux-bug)

As I commented in Trello card, this is due of the asbence of the Redux devtools in the global window object, that's why it throws that error.

Please have a look and let mek now if this fixes it on your mobile or the other guy on his desktop but I'm confident of this fix.